### PR TITLE
feat: allow hosting on pythonanywhere

### DIFF
--- a/src/inventory_trail/settings.py
+++ b/src/inventory_trail/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-zv_@gdkj*&3%enhv4^^sz&4n+%6*-bvav%!x4+401mv-z(2=+*
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["jhwan.pythonanywhere.com"]
 
 
 # Application definition


### PR DESCRIPTION
We will deploy our app on pythonanywhere.com (it's completely free) until we are ready for people to start testing the app. Then we may move to another hosting service.